### PR TITLE
Prevent systemd units from entering "active (exited)" state

### DIFF
--- a/deploy/etc/systemd/system/<environment>-<type>-iiif-auth-shim.service
+++ b/deploy/etc/systemd/system/<environment>-<type>-iiif-auth-shim.service
@@ -5,7 +5,7 @@ After=docker.service
 
 [Service]
 Type=simple
-RemainAfterExit=yes
+RemainAfterExit=no
 WorkingDirectory=/opt/bfi/iiif-auth-shim
 ExecStartPre=/usr/local/bin/docker-compose --file /opt/bfi/iiif-auth-shim/<environment>/<type>/docker-compose.yml --env-file /etc/opt/bfi/iiif-auth-shim/<environment>/<type>/config.env pull --include-deps
 ExecStart=/usr/local/bin/docker-compose --file /opt/bfi/iiif-auth-shim/<environment>/<type>/docker-compose.yml --env-file /etc/opt/bfi/iiif-auth-shim/<environment>/<type>/config.env up --remove-orphans --abort-on-container-exit --no-color


### PR DESCRIPTION
An event occurred which caused the Docker processes to exit prematurely. This left the systemd unit in a state of `active (exited)`, and thus a simple `system start` was not sufficient to bring the process back up.

This change switches the systemd unit flag `RemainAfterExit` from `yes to `no`, to ensure that when the process exits again it will correctly enter a failed state.